### PR TITLE
adds slim template lang support

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Easy on the eyes. Maintain 6:1 contrast between text and background colors. [WCA
 - GitHub Markdown
 - HTML
 - JavaScript
-- Ruby / RoR / ERB
+- Ruby / RoR / ERB / Slim (with [slim-language package](https://github.com/ianmitchell/slim-language))
 - Python
 
 More coming soon. Write me if you need support for specific language.

--- a/code-samples/slim-sample.slim
+++ b/code-samples/slim-sample.slim
@@ -1,0 +1,35 @@
+doctype html
+html
+  head
+    title Slim Examples
+    meta name="keywords" content="template language"
+    meta name="author" content=author
+    javascript:
+      alert('Slim supports embedded javascript!')
+  body
+    nav: ul.navbar style="position: fixed; top: 0;"
+      li: a href="/test" Home
+      li: a(href="/about") About
+
+    h1 Markup examples
+
+    #content
+      p This example shows you how a basic Slim file looks like.
+
+      == yield
+
+      - unless items.empty?
+        table
+          - items.each do |item|
+            tr
+              td.name = item.name
+              td.price = item.price
+      - else
+        p
+         | No items found.  Please add some inventory.
+           Thank you!
+
+    div id="footer"
+      = render 'footer'
+      | Copyright © #{year} #{author}
+      | #{if ruby.works? 'good' else 'bad'}

--- a/styles/languages/slim.less
+++ b/styles/languages/slim.less
@@ -1,0 +1,14 @@
+.text.slim {
+
+  .entity.name.tag,
+  .punctuation.definition.tag {
+    color: @text-purple;
+    background-color: @bg-purple;
+  }
+
+  .entity.attribute-name {
+    color: @text-blue;
+    background-color: @bg-blue;
+  }
+
+}


### PR DESCRIPTION
Since I wanted it, I implemented basic support for slim (and coffee script). Hope it's alright for you.

Note that it only works perfectly with the package mentioned in the Readme. There are two other, much more popular packages that promise hightlighting for slim that produce sub-par output of HTML. The highlighting for them is then also not correct, but that's a problem I've seen with many other styles as well.

Primarily the problems with both of them are: not recognizing attributes (they are recognized as tags) and all tags begin at the beginning of the line, which is ok if you only apply `color` to the tag, but if you use `background` it looks weird.

![screen shot 2016-08-13 at 2 18 51](https://cloud.githubusercontent.com/assets/1738261/17640260/4c9b8fac-60fc-11e6-84df-5501bd1328fc.png)
