### PR TITLE
adds CoffeeScript lang support

### DIFF
--- a/code-samples/coffee-sample.coffee
+++ b/code-samples/coffee-sample.coffee
@@ -1,0 +1,118 @@
+# Assignment:
+number   = 42
+opposite = true
+
+# Conditions:
+number = -42 if opposite
+
+# Functions:
+square = (x) -> x * x
+
+# Arrays:
+list = [1, 2, 3, 4, 5]
+
+# Objects:
+math =
+  root:   Math.sqrt
+  square: square
+  cube:   (x) -> x * square x
+
+# Splats:
+race = (winner, runners...) ->
+  print winner, runners
+
+# Existence:
+alert "I knew it!" if elvis?
+
+# Array comprehensions:
+cubes = (math.cube num for num in list)
+
+
+@app.directive 'customInput', ->
+  restrict: 'E'
+  scope:
+    name: '@'
+    errors: '='
+    label: '@'
+    type: '@'
+  templateUrl: 'inputs/input.html'
+
+@app.constant "$keyCodes",
+  A: 65,
+  B: 66,
+  C: 67,
+  D: 68,
+  E: 69,
+  F: 70
+
+hash_assignment =
+  a: 'test'
+
+x = ->
+  method_call
+    with: 'arguments'
+  hash_assignment_in_function =
+    a: 'test'
+    b: 'test'
+
+method_that_returns_hash = ->
+  hello: 'world'
+  how: 'are you?'
+
+method = (val, var1: 'test') ->
+  if var1 == 'test'
+    console.log val
+  else
+    console.log 'ERROR'
+
+method 'test'
+
+setTimeout ->
+  method('test')
+, 2000
+
+false
+
+fill = (container, liquid = "coffee") ->
+  "Filling the #{container} with #{liquid}..."
+
+
+# Eat lunch.
+eat food for food in ['toast', 'cheese', 'wine']
+
+# Fine five course dining.
+courses = ['greens', 'caviar', 'truffles', 'roast', 'cake']
+menu i + 1, dish for dish, i in courses
+
+# Health conscious meal.
+foods = ['broccoli', 'spinach', 'chocolate']
+eat food for food in foods when food isnt 'chocolate'
+
+
+class Animal
+  constructor: (@name) ->
+
+  move: (meters) ->
+    alert @name + " moved #{meters}m."
+
+class Snake extends Animal
+  move: ->
+    alert "Slithering..."
+    super 5
+
+class Horse extends Animal
+  move: ->
+    alert "Galloping..."
+    super 45
+
+sam = new Snake "Sammy the Python"
+tom = new Horse "Tommy the Palomino"
+
+sam.move()
+tom.move()
+
+
+author = "Wittgenstein"
+quote  = "A picture is a fact. -- #{ author }"
+
+sentence = "#{ 22 / 7 } is a decent approximation of π"

--- a/index.less
+++ b/index.less
@@ -15,3 +15,4 @@
 @import 'languages/github-markdown';
 @import 'languages/python';
 @import 'languages/elixir';
+@import 'languages/coffee';

--- a/styles/languages/coffee.less
+++ b/styles/languages/coffee.less
@@ -1,0 +1,37 @@
+.source.coffee {
+
+  .string.regexp {
+    color: @text-green;
+    background-color: @bg-green;
+
+    > .regexp { background-color: transparent; }
+  }
+
+  .keyword.special-method,
+  .support.function.kernel {
+    color: @text-orange;
+  	background-color: @bg-orange;
+  }
+
+  .storage.type.function {
+    color: @text-purple;
+    background-color: @bg-purple;
+  }
+
+  .variable.instance {
+    color: @text-orange;
+    background-color: @bg-orange;
+  }
+
+  .leading-whitespace + .variable.assignment,
+  .meta.function .entity.name.function  {
+    color: @text-blue;
+  	background-color: @bg-blue;
+  }
+
+  .keyword.operator.new,
+  .storage.type.class {
+    color: @text-purple;
+  	background-color: @bg-purple;
+  }
+}


### PR DESCRIPTION
Support coffee script with the build in style. It's sadly not perfect because the semantic classes are not always consistently or correctly applied in JS as they are in JS. I had to do a workaround so the keys of the hash in this syntax work:

``` coffee
hash =
  this: 'is a short'
  syntax: 'for hashes'
  in: 'coffee script'
```

See: `.leading-whitespace + .variable.assignment`

That produces incorrect output in some other syntax styles, however. Not sure how to go about this. Looks overall acceptable I think, however, although it's kind of frustrating.

![screen shot 2016-08-13 at 2 24 42](https://cloud.githubusercontent.com/assets/1738261/17640300/1b51b24a-60fd-11e6-8b30-dd90119451d5.png)
