### PR TITLE
Update CHANGELOG by sorting by lastest release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,15 @@
-## 0.1.0 - First Release
+
+## 0.5.0
+* Major refactor
+* Update HTML highlighting
+* Lots minor fixes and updates
+
+## 0.4.2
+* Adds CoffeeScript support
+* Adds Slim support
+
+## 0.4.1
+* Adds Elixir Language support
 
 ## 0.4.0
 * Contrast increased
@@ -8,14 +19,4 @@
 * Python support added
 * RoR support added
 
-## 0.4.1
-* Adds Elixir Language support
-
-## 0.4.2
-* Adds CoffeeScript support
-* Adds Slim support
-
-## 0.5.0
-* Major refactor
-* Update HTML highlighting
-* Lots minor fixes and updates
+## 0.1.0 - First Release


### PR DESCRIPTION
Man, I love your theme, but your CHANGELOG should have first the lastest release and then the older ones. Don't you think?
