### PR TITLE
Fixed deprecation warnings in Atom

### DIFF
--- a/styles/languages/_base.less
+++ b/styles/languages/_base.less
@@ -1,117 +1,117 @@
-.base { color: @base1; }
+.syntax--base { color: @base1; }
 
-.sec { color: @base2; }
+.syntax--sec { color: @base2; }
 
-.comment { color: @base3; }
+.syntax--comment { color: @base3; }
 
-.orange {
+.syntax--orange {
   color: @orange-text;
 	background-color: @orange-bg;
 }
 
-.orange-sec { color: @orange-text-sec; }
+.syntax--orange-sec { color: @orange-text-sec; }
 
-.green {
+.syntax--green {
   color: @green-text;
 	background-color: @green-bg;
 }
 
-.green-sec { color: @green-text-sec; }
+.syntax--green-sec { color: @green-text-sec; }
 
-.teal {
+.syntax--teal {
   color: @teal-text;
 	background-color: @teal-bg;
 }
 
-.teal-sec { color: @teal-text-sec; }
+.syntax--teal-sec { color: @teal-text-sec; }
 
-.blue {
+.syntax--blue {
   color: @blue-text;
 	background-color: @blue-bg;
 }
 
-.blue-sec { color: @blue-text-sec; }
+.syntax--blue-sec { color: @blue-text-sec; }
 
-.purple {
+.syntax--purple {
   color: @purple-text;
 	background-color: @purple-bg;
 }
 
-.purple-sec { color: @purple-text-sec; }
+.syntax--purple-sec { color: @purple-text-sec; }
 
 
-.reset {
+.syntax--reset {
   color: inherit;
   background-color: transparent;
 }
 
 .reset_all {
-  .keyword.control,
-  .string.quoted,
-  .string.regexp,
-  .constant.numeric,
-  .constant.keyword,
-  .constant.symbol,
-  .constant.language,
-  .entity.name.tag,
-  .meta.embedded {
-    .reset();
+  .syntax--keyword.syntax--control,
+  .syntax--string.syntax--quoted,
+  .syntax--string.syntax--regexp,
+  .syntax--constant.syntax--numeric,
+  .syntax--constant.syntax--keyword,
+  .syntax--constant.syntax--symbol,
+  .syntax--constant.syntax--language,
+  .syntax--entity.syntax--name.syntax--tag,
+  .syntax--meta.syntax--embedded {
+    .syntax--reset();
   }
 
-  .meta.embedded {
-    .punctuation.embedded { .reset; }
+  .syntax--meta.syntax--embedded {
+    .syntax--punctuation.syntax--embedded { .syntax--reset; }
 
-    .string.quoted {
-      .punctuation.definition { .reset; }
+    .syntax--string.syntax--quoted {
+      .syntax--punctuation.syntax--definition { .syntax--reset; }
     }
   }
 }
 
 // Global Highlighting
 
-.keyword.control {
-  .purple();
+.syntax--keyword.syntax--control {
+  .syntax--purple();
 }
 
-.constant.keyword,
-.constant.symbol {
-  .blue();
+.syntax--constant.syntax--keyword,
+.syntax--constant.syntax--symbol {
+  .syntax--blue();
 }
 
-.constant.numeric,
-.constant.language {
-  .teal();
+.syntax--constant.syntax--numeric,
+.syntax--constant.syntax--language {
+  .syntax--teal();
 }
 
-.string.quoted,
-.string.regexp {
-  .green();
+.syntax--string.syntax--quoted,
+.syntax--string.syntax--regexp {
+  .syntax--green();
   .reset_all();
 
-  .punctuation.definition {
+  .syntax--punctuation.syntax--definition {
     color: @green-text-sec;
   }
 }
 
-.comment {
+.syntax--comment {
   color: @base3;
   font-style: italic;
 }
 
-.meta.embedded:not(.php) {
+.syntax--meta.syntax--embedded:not(.syntax--php) {
   .settings-embedded-mix();
 }
 
-.bold { font-weight: bold; }
+.syntax--bold { font-weight: bold; }
 
-.italic { font-style: italic; }
+.syntax--italic { font-style: italic; }
 
-.invalid {
-  &.deprecated {
+.syntax--invalid {
+  &.syntax--deprecated {
     color: @syntax-deprecated-fg !important;
     background-color: @syntax-deprecated-bg !important;
   }
-  &.illegal {
+  &.syntax--illegal {
     color: @syntax-illegal-fg !important;
     background-color: @syntax-illegal-bg !important;
   }
@@ -119,22 +119,22 @@
 
 // Mixins
 
-.attribute-mix {
-  .sec();
+.syntax--attribute-mix {
+  .syntax--sec();
   font-style: italic;
 }
 
 .embedded-simple-mix {
-  .orange();
+  .syntax--orange();
   .reset_all();
 
-  .punctuation.embedded {
+  .syntax--punctuation.syntax--embedded {
     color: @orange-text-sec;
   }
 }
 
 .embedded-full-mix {
-  .punctuation.embedded {
-    .orange();
+  .syntax--punctuation.syntax--embedded {
+    .syntax--orange();
   }
 }

--- a/styles/languages/c.less
+++ b/styles/languages/c.less
@@ -1,5 +1,5 @@
-.source.c {
+.syntax--source.syntax--c {
 
-  .storage.type { .orange; }
+  .syntax--storage.syntax--type { .syntax--orange; }
 
 }

--- a/styles/languages/clojure.less
+++ b/styles/languages/clojure.less
@@ -1,11 +1,11 @@
-.source.clojure {
+.syntax--source.syntax--clojure {
 
-  .storage.control { .purple; }
+  .syntax--storage.syntax--control { .syntax--purple; }
 
 }
 
-.ink.result.inline {
-	.ink.leaf {
-		.text { .comment }
+.syntax--ink.syntax--result.syntax--inline {
+	.syntax--ink.syntax--leaf {
+		.syntax--text { .syntax--comment }
 	}
 }

--- a/styles/languages/coffee.less
+++ b/styles/languages/coffee.less
@@ -1,16 +1,16 @@
-.source.coffee {
+.syntax--source.syntax--coffee {
 
-  .storage.type.class,
-  .storage.type.function,
-  .meta.inline.function {
-    .purple;
+  .syntax--storage.syntax--type.syntax--class,
+  .syntax--storage.syntax--type.syntax--function,
+  .syntax--meta.syntax--inline.syntax--function {
+    .syntax--purple;
 
-    .function { .reset; }
+    .syntax--function { .syntax--reset; }
   }
 
-  .support.class { .orange; }
+  .syntax--support.syntax--class { .syntax--orange; }
 
-  .comment {
-    .storage.type.class { .reset; }
+  .syntax--comment {
+    .syntax--storage.syntax--type.syntax--class { .syntax--reset; }
   }
 }

--- a/styles/languages/crystal.less
+++ b/styles/languages/crystal.less
@@ -1,15 +1,15 @@
-.source.crystal {
+.syntax--source.syntax--crystal {
 
-  .support.class.struct,
-  .keyword.control.unsigned-int,
-  .keyword.control.signed-int,
-  .keyword.control.float {
-    .orange;
+  .syntax--support.syntax--class.syntax--struct,
+  .syntax--keyword.syntax--control.syntax--unsigned-int,
+  .syntax--keyword.syntax--control.syntax--signed-int,
+  .syntax--keyword.syntax--control.syntax--float {
+    .syntax--orange;
   }
 
-  .support.function.kernel,
-  .keyword.other.special-method {
-    .purple;
+  .syntax--support.syntax--function.syntax--kernel,
+  .syntax--keyword.syntax--other.syntax--special-method {
+    .syntax--purple;
   }
   
 }

--- a/styles/languages/cs.less
+++ b/styles/languages/cs.less
@@ -1,8 +1,8 @@
-// .source.cs {
-//   .meta {
-//     .uno-3();
+// .syntax--source.syntax--cs {
+//   .syntax--meta {
+//     .syntax--uno-3();
 //   }
-//   .method {
-//     .uno-2();
+//   .syntax--method {
+//     .syntax--uno-2();
 //   }
 // }

--- a/styles/languages/css.less
+++ b/styles/languages/css.less
@@ -1,26 +1,26 @@
-.source.css {
+.syntax--source.syntax--css {
 
-  .entity.tag,
-  .entity.attribute-name {
-    .purple;
+  .syntax--entity.syntax--tag,
+  .syntax--entity.syntax--attribute-name {
+    .syntax--purple;
 
-    .entity.attribute-name { .reset; }
+    .syntax--entity.syntax--attribute-name { .syntax--reset; }
 
-    .punctuation.definition { .purple-sec; }
+    .syntax--punctuation.syntax--definition { .syntax--purple-sec; }
   }
 
-  .support.constant { .green; }
+  .syntax--support.syntax--constant { .syntax--green; }
 
-  .constant.rgb-value { .teal; }
+  .syntax--constant.syntax--rgb-value { .syntax--teal; }
 
-  .keyword.important { .orange; }
+  .syntax--keyword.syntax--important { .syntax--orange; }
 
-  .keyword.other.unit {
-    .teal;
-    .teal-sec;
+  .syntax--keyword.syntax--other.syntax--unit {
+    .syntax--teal;
+    .syntax--teal-sec;
   }
 
-  .punctuation.terminator,
-  .punctuation.separator { .sec; }
+  .syntax--punctuation.syntax--terminator,
+  .syntax--punctuation.syntax--separator { .syntax--sec; }
 
 }

--- a/styles/languages/elixir.less
+++ b/styles/languages/elixir.less
@@ -1,18 +1,18 @@
-.source.elixir {
+.syntax--source.syntax--elixir {
 
-  .keyword.other.special-method { .orange; }
+  .syntax--keyword.syntax--other.syntax--special-method { .syntax--orange; }
 
-  .constant.language { .teal; }
+  .syntax--constant.syntax--language { .syntax--teal; }
 
-  .constant.symbol {
-    .punctuation.definition { .blue-sec; }
+  .syntax--constant.syntax--symbol {
+    .syntax--punctuation.syntax--definition { .syntax--blue-sec; }
   }
 
 
-  &.embedded {
+  &.syntax--embedded {
 
-    .keyword.other.special-method,
-    .constant.language { .reset; }
+    .syntax--keyword.syntax--other.syntax--special-method,
+    .syntax--constant.syntax--language { .syntax--reset; }
   }
 
 }

--- a/styles/languages/elm.less
+++ b/styles/languages/elm.less
@@ -1,14 +1,14 @@
-.source.elm {
+.syntax--source.syntax--elm {
 
-  .meta.import {
-    .keyword.other { .purple; }
+  .syntax--meta.syntax--import {
+    .syntax--keyword.syntax--other { .syntax--purple; }
   }
 
-  .support.type,
-  .storage.type { .orange; }
+  .syntax--support.syntax--type,
+  .syntax--storage.syntax--type { .syntax--orange; }
 
-  .constant.other { .blue; }
+  .syntax--constant.syntax--other { .syntax--blue; }
 
-  .support.constant { .teal; }
+  .syntax--support.syntax--constant { .syntax--teal; }
 
 }

--- a/styles/languages/gfm.less
+++ b/styles/languages/gfm.less
@@ -1,64 +1,64 @@
-.source.gfm {
-  .markup {
-    &.heading {
+.syntax--source.syntax--gfm {
+  .syntax--markup {
+    &.syntax--heading {
       display: inline-block;
-      .purple;
+      .syntax--purple;
 
-      .heading { .reset; }
+      .syntax--heading { .syntax--reset; }
 
-      .marker { .purple-sec; }
+      .syntax--marker { .syntax--purple-sec; }
     }
 
-    &.code,
-    &.raw {
+    &.syntax--code,
+    &.syntax--raw {
       display: inline-block;
-      .orange;
+      .syntax--orange;
 
-      .support.function.actionpack,
-      .support.function.viewhelpers,
-      .support.function.activerecord,
-      .support.function.activesupport,
-      .keyword.special-method,
-      .variable.this,
-      .keyword.new,
-      .constant.numeric,
-      .constant.boolean,
-      .constant.nil,
-      .constant.keyword,
-      .string.quoted,
-      .storage.control,
-      .storage.var,
-      .keyword.control,
-      .constant.symbol {
-        .reset;
+      .syntax--support.syntax--function.syntax--actionpack,
+      .syntax--support.syntax--function.syntax--viewhelpers,
+      .syntax--support.syntax--function.syntax--activerecord,
+      .syntax--support.syntax--function.syntax--activesupport,
+      .syntax--keyword.syntax--special-method,
+      .syntax--variable.syntax--this,
+      .syntax--keyword.syntax--new,
+      .syntax--constant.syntax--numeric,
+      .syntax--constant.syntax--boolean,
+      .syntax--constant.syntax--nil,
+      .syntax--constant.syntax--keyword,
+      .syntax--string.syntax--quoted,
+      .syntax--storage.syntax--control,
+      .syntax--storage.syntax--var,
+      .syntax--keyword.syntax--control,
+      .syntax--constant.syntax--symbol {
+        .syntax--reset;
       }
     }
 
-    &.italic { font-style: italic; }
+    &.syntax--italic { font-style: italic; }
 
-    &.bold { font-weight: bold; }
+    &.syntax--bold { font-weight: bold; }
 
-    &.strike { text-decoration: line-through; }
+    &.syntax--strike { text-decoration: line-through; }
   }
 
-  .link {
+  .syntax--link {
     display: inline-block;
-    .blue();
+    .syntax--blue();
 
-    .link { .reset; }
+    .syntax--link { .syntax--reset; }
 
-    .punctuation.definition { .blue-sec; }
+    .syntax--punctuation.syntax--definition { .syntax--blue-sec; }
   }
 
-  .comment {
+  .syntax--comment {
     display: inline-block;
     font-style: normal;
-    .green;
+    .syntax--green;
 
 
-    .link,
-    .comment { .reset; }
+    .syntax--link,
+    .syntax--comment { .syntax--reset; }
 
-    .support.quote { .green-sec; }
+    .syntax--support.syntax--quote { .syntax--green-sec; }
   }
 }

--- a/styles/languages/go.less
+++ b/styles/languages/go.less
@@ -1,27 +1,27 @@
-.source.go {
+.syntax--source.syntax--go {
 
-  .keyword {
-    &.function,
-    &.type,
-    &.package,
-    &.import {
-      .purple;
+  .syntax--keyword {
+    &.syntax--function,
+    &.syntax--type,
+    &.syntax--package,
+    &.syntax--import {
+      .syntax--purple;
     }
 
   }
 
-  .storage.type{
-    .orange;
+  .syntax--storage.syntax--type{
+    .syntax--orange;
   }
 
-  .constant.language {
-    .teal;
+  .syntax--constant.syntax--language {
+    .syntax--teal;
   }
 
 }
 
-.gohtml {
-  .punctuation.embedded {
-    .sec;
+.syntax--gohtml {
+  .syntax--punctuation.syntax--embedded {
+    .syntax--sec;
   }
 }

--- a/styles/languages/haskell.less
+++ b/styles/languages/haskell.less
@@ -1,10 +1,10 @@
-.source.haskell {
+.syntax--source.syntax--haskell {
 
-  .keyword.other:not(.arrow):not(.double-colon) { .purple; }
+  .syntax--keyword.syntax--other:not(.syntax--arrow):not(.syntax--double-colon) { .syntax--purple; }
 
-  .entity.name.type { .orange; }
+  .syntax--entity.syntax--name.syntax--type { .syntax--orange; }
 
-  .support.tag.prelude { .teal; }
+  .syntax--support.syntax--tag.syntax--prelude { .syntax--teal; }
 
 
 }

--- a/styles/languages/html.less
+++ b/styles/languages/html.less
@@ -1,95 +1,95 @@
-.html {
+.syntax--html {
 
-  .meta.tag {
-    .sec;
+  .syntax--meta.syntax--tag {
+    .syntax--sec;
 
-    .entity.attribute-name { .attribute-mix; }
+    .syntax--entity.syntax--attribute-name { .syntax--attribute-mix; }
 
-    .entity.tag { .purple; }
+    .syntax--entity.syntax--tag { .syntax--purple; }
 
   }
 
-  &.htmlplus {
+  &.syntax--htmlplus {
 
-    .meta.tag {
-      .entity.tag {
-        .reset;
-        .base;
+    .syntax--meta.syntax--tag {
+      .syntax--entity.syntax--tag {
+        .syntax--reset;
+        .syntax--base;
       }
     }
 
-    .string.content { .blue; }
+    .syntax--string.syntax--content { .syntax--blue; }
   }
 
 }
 
-.mustache {
-  .meta.tag.template {
-    .orange;
+.syntax--mustache {
+  .syntax--meta.syntax--tag.syntax--template {
+    .syntax--orange;
     .reset_all;
 
-    .entity.name.tag {
-      .orange-sec;
+    .syntax--entity.syntax--name.syntax--tag {
+      .syntax--orange-sec;
 
-      .entity.name.function {
+      .syntax--entity.syntax--name.syntax--function {
         color: @orange-text;
       }
     }
   }
 }
 
-.htmlbars {
+.syntax--htmlbars {
 
-  .meta.tag:not(.html) {
-    .base;
+  .syntax--meta.syntax--tag:not(.syntax--html) {
+    .syntax--base;
 
-    .punctuation.definition {
-      .sec;
+    .syntax--punctuation.syntax--definition {
+      .syntax--sec;
     }
   }
 
-  .meta.tag.inline {
-    .punctuation.definition {
-      .reset();
+  .syntax--meta.syntax--tag.syntax--inline {
+    .syntax--punctuation.syntax--definition {
+      .syntax--reset();
 
-      &.inline {
-        .sec;
+      &.syntax--inline {
+        .syntax--sec;
       }
     }
   }
 
-  .support.function.builtin { .purple; }
+  .syntax--support.syntax--function.syntax--builtin { .syntax--purple; }
 
-  .string.quoted {
-    .function.inline {
-      .reset;
+  .syntax--string.syntax--quoted {
+    .syntax--function.syntax--inline {
+      .syntax--reset;
     }
-    .punctuation.definition.tag {
+    .syntax--punctuation.syntax--definition.syntax--tag {
       color: @green-text-sec !important;
     }
   }
 
-  .constant.symbol {
-    .reset();
+  .syntax--constant.syntax--symbol {
+    .syntax--reset();
   }
 }
 
-.haml {
+.syntax--haml {
 
-  .meta.tag {
-    .purple;
-    .punctuation.definition { .purple-sec; }
+  .syntax--meta.syntax--tag {
+    .syntax--purple;
+    .syntax--punctuation.syntax--definition { .syntax--purple-sec; }
   }
 
-  .meta.section.attributes {
-    .sec;
+  .syntax--meta.syntax--section.syntax--attributes {
+    .syntax--sec;
 
-    .constant.symbol {
-      .reset;
-      .attribute-mix;
+    .syntax--constant.syntax--symbol {
+      .syntax--reset;
+      .syntax--attribute-mix;
     }
   }
 
-  .entity.tag.class { .blue; }
+  .syntax--entity.syntax--tag.syntax--class { .syntax--blue; }
 
 }

--- a/styles/languages/jade.less
+++ b/styles/languages/jade.less
@@ -1,14 +1,14 @@
-.source.jade {
+.syntax--source.syntax--jade {
 
-  .entity.name.tag,
-  .entity.class { .purple(); }
+  .syntax--entity.syntax--name.syntax--tag,
+  .syntax--entity.syntax--class { .syntax--purple(); }
 
-  .complete_tag {
-    .sec;
+  .syntax--complete_tag {
+    .syntax--sec;
 
-    .entity.attribute-name.tag { .attribute-mix(); }
+    .syntax--entity.syntax--attribute-name.syntax--tag { .syntax--attribute-mix(); }
 
-    .text { .base; }
+    .syntax--text { .syntax--base; }
   }
 
 }

--- a/styles/languages/java.less
+++ b/styles/languages/java.less
@@ -1,11 +1,11 @@
-.source.java {
+.syntax--source.syntax--java {
 
-  .meta.class,
-  .meta.method {
-    .storage.modifier { .purple; }
+  .syntax--meta.syntax--class,
+  .syntax--meta.syntax--method {
+    .syntax--storage.syntax--modifier { .syntax--purple; }
   }
 
-  .storage.type.primitive,
-  .storage.type.annotation { .orange; }
+  .syntax--storage.syntax--type.syntax--primitive,
+  .syntax--storage.syntax--type.syntax--annotation { .syntax--orange; }
 
 }

--- a/styles/languages/javascript.less
+++ b/styles/languages/javascript.less
@@ -1,30 +1,30 @@
-.source.js {
+.syntax--source.syntax--js {
 
-  .storage.type.function {
-    .purple;
+  .syntax--storage.syntax--type.syntax--function {
+    .syntax--purple;
 
-    .function { .reset; }
+    .syntax--function { .syntax--reset; }
   }
 
-  .constant.language { .teal; }
+  .syntax--constant.syntax--language { .syntax--teal; }
 
-  .string.unquoted { .blue; }
+  .syntax--string.syntax--unquoted { .syntax--blue; }
 
-  .comment {
-    .storage.type.class { .reset; }
+  .syntax--comment {
+    .syntax--storage.syntax--type.syntax--class { .syntax--reset; }
   }
 
-  .meta.tag.jsx {
+  .syntax--meta.syntax--tag.syntax--jsx {
 
-    .entity.tag { .purple; }
+    .syntax--entity.syntax--tag { .syntax--purple; }
 
-    .entity.other.attribute-name.jsx {
-      .sec;
+    .syntax--entity.syntax--other.syntax--attribute-name.syntax--jsx {
+      .syntax--sec;
       font-style: italic;
     }
 
-    .punctuation.definition.tag,
-    .keyword.operator.assignment { .sec; }
+    .syntax--punctuation.syntax--definition.syntax--tag,
+    .syntax--keyword.syntax--operator.syntax--assignment { .syntax--sec; }
 
   }
 }

--- a/styles/languages/json.less
+++ b/styles/languages/json.less
@@ -1,28 +1,28 @@
-.source.json {
+.syntax--source.syntax--json {
 
-  .meta.structure.dictionary {
-    .string.quoted {
-      .reset;
-      .punctuation.definition { .sec; }
+  .syntax--meta.syntax--structure.syntax--dictionary {
+    .syntax--string.syntax--quoted {
+      .syntax--reset;
+      .syntax--punctuation.syntax--definition { .syntax--sec; }
     }
 
-    .array {
-      .string.quoted {
-        .green;
-        .punctuation.definition { .green-sec; }
+    .syntax--array {
+      .syntax--string.syntax--quoted {
+        .syntax--green;
+        .syntax--punctuation.syntax--definition { .syntax--green-sec; }
       }
     }
 
-    .punctuation.key-value { .sec; }
+    .syntax--punctuation.syntax--key-value { .syntax--sec; }
   }
 
-  .meta.structure.dictionary, .meta.structure.array {
-    & > .value.json > .string.quoted.json {
-      .green;
+  .syntax--meta.syntax--structure.syntax--dictionary, .syntax--meta.syntax--structure.syntax--array {
+    & > .syntax--value.syntax--json > .syntax--string.syntax--quoted.syntax--json {
+      .syntax--green;
 
     }
   }
 
-  .constant.language { .teal; }
+  .syntax--constant.syntax--language { .syntax--teal; }
 
 }

--- a/styles/languages/latex.less
+++ b/styles/languages/latex.less
@@ -1,27 +1,27 @@
-.latex {
+.syntax--latex {
 
-  .keyword.control,
-  .support.function {
-    .purple;
+  .syntax--keyword.syntax--control,
+  .syntax--support.syntax--function {
+    .syntax--purple;
 
-    .punctuation { .purple-sec; }
+    .syntax--punctuation { .syntax--purple-sec; }
   }
 
-  .meta.preamble {
-    .support.class { .blue; }
+  .syntax--meta.syntax--preamble {
+    .syntax--support.syntax--class { .syntax--blue; }
   }
 
-  .variable.parameter { .orange; }
+  .syntax--variable.syntax--parameter { .syntax--orange; }
 
-  .constant.other { .teal; }
+  .syntax--constant.syntax--other { .syntax--teal; }
 
-  .punctuation.definition,
-  .punctuation.section { .sec; }
+  .syntax--punctuation.syntax--definition,
+  .syntax--punctuation.syntax--section { .syntax--sec; }
 
-  .string.quoted {
-    .reset;
+  .syntax--string.syntax--quoted {
+    .syntax--reset;
 
-    .punctuation { color: inherit; }
+    .syntax--punctuation { color: inherit; }
   }
 
 }

--- a/styles/languages/less.less
+++ b/styles/languages/less.less
@@ -1,11 +1,11 @@
-.source.less {
+.syntax--source.syntax--less {
 
-  .keyword.control.at-rule {
-    .punctuation.definition { .purple-sec; }
+  .syntax--keyword.syntax--control.syntax--at-rule {
+    .syntax--punctuation.syntax--definition { .syntax--purple-sec; }
   }
 
-  .variable { .blue; }
+  .syntax--variable { .syntax--blue; }
 
-  .variable.other.interpolation { .reset; }
+  .syntax--variable.syntax--other.syntax--interpolation { .syntax--reset; }
 
 }

--- a/styles/languages/liquid.less
+++ b/styles/languages/liquid.less
@@ -1,10 +1,10 @@
-.liquid {
+.syntax--liquid {
   
-  .constant.language { .teal; }
+  .syntax--constant.syntax--language { .syntax--teal; }
 
-  .entity.name.tag { .purple; }
+  .syntax--entity.syntax--name.syntax--tag { .syntax--purple; }
 
-  .punctuation.tag.liquid,
-  .punctuation.output.liquid { .settings-embedded-mix; }
+  .syntax--punctuation.syntax--tag.syntax--liquid,
+  .syntax--punctuation.syntax--output.syntax--liquid { .settings-embedded-mix; }
 
 }

--- a/styles/languages/mediawiki.less
+++ b/styles/languages/mediawiki.less
@@ -1,24 +1,24 @@
-// .mediawiki {
-//   .uno-1();
-//   .punctuation-mixin();
-//   .wiki-link {
-//     .uno-2();
+// .syntax--mediawiki {
+//   .syntax--uno-1();
+//   .syntax--punctuation-mixin();
+//   .syntax--wiki-link {
+//     .syntax--uno-2();
 //   }
-//   .heading {
-//     .duo-1();
+//   .syntax--heading {
+//     .syntax--duo-1();
 //   }
-//   .function-call {
-//     .duo-2();
+//   .syntax--function-call {
+//     .syntax--duo-2();
 //   }
-//   .value {
-//     .duo-1();
+//   .syntax--value {
+//     .syntax--duo-1();
 //   }
-//   .fix_this_later {
-//     .uno-2();
+//   .syntax--fix_this_later {
+//     .syntax--uno-2();
 //   }
-//   .pipe,
-//   .link,
-//   .tag {
-//     .uno-4();
+//   .syntax--pipe,
+//   .syntax--link,
+//   .syntax--tag {
+//     .syntax--uno-4();
 //   }
 // }

--- a/styles/languages/php.less
+++ b/styles/languages/php.less
@@ -1,30 +1,30 @@
-.php {
+.syntax--php {
 
-  .storage.type.class,
-  .storage.type.function { .purple; }
+  .syntax--storage.syntax--type.syntax--class,
+  .syntax--storage.syntax--type.syntax--function { .syntax--purple; }
 
-  .constant.language { .teal; }
+  .syntax--constant.syntax--language { .syntax--teal; }
 
-  .variable {
-    &.global {
-      .blue;
-      .punctuation.definition { .blue-sec; }
+  .syntax--variable {
+    &.syntax--global {
+      .syntax--blue;
+      .syntax--punctuation.syntax--definition { .syntax--blue-sec; }
     }
 
-    .punctuation.definition { .sec; }
+    .syntax--punctuation.syntax--definition { .syntax--sec; }
   }
 
-  .support.function.construct { .orange; }
+  .syntax--support.syntax--function.syntax--construct { .syntax--orange; }
 
-  .punctuation {
-    // &.section.array,
-    &.terminator { .sec; }
+  .syntax--punctuation {
+    // &.syntax--section.syntax--array,
+    &.syntax--terminator { .syntax--sec; }
   }
 
-  .meta.embedded {
-    .reset;
+  .syntax--meta.syntax--embedded {
+    .syntax--reset;
 
-    .punctuation.embedded { .orange; }
+    .syntax--punctuation.syntax--embedded { .syntax--orange; }
   }
 
 }

--- a/styles/languages/python.less
+++ b/styles/languages/python.less
@@ -1,18 +1,18 @@
-.source.python {
+.syntax--source.syntax--python {
 
-  .storage.type.class,
-  .storage.type.function { .purple; }
+  .syntax--storage.syntax--type.syntax--class,
+  .syntax--storage.syntax--type.syntax--function { .syntax--purple; }
 
-  .meta.structure.dictionary.key {
-    .numeric,
-    .string.quoted {
-      .blue;
-      .punctuation.definition { .blue-sec; }
+  .syntax--meta.syntax--structure.syntax--dictionary.syntax--key {
+    .syntax--numeric,
+    .syntax--string.syntax--quoted {
+      .syntax--blue;
+      .syntax--punctuation.syntax--definition { .syntax--blue-sec; }
     }
   }
 
-  .constant.language { .teal; }
+  .syntax--constant.syntax--language { .syntax--teal; }
 
-  .variable.self { .orange; }
+  .syntax--variable.syntax--self { .syntax--orange; }
 
 }

--- a/styles/languages/ruby.less
+++ b/styles/languages/ruby.less
@@ -1,27 +1,27 @@
-.ruby {
+.syntax--ruby {
 
-  .constant.symbol {
-    .punctuation.definition { .blue-sec; }
+  .syntax--constant.syntax--symbol {
+    .syntax--punctuation.syntax--definition { .syntax--blue-sec; }
   }
 
-  .support.function.actionpack,
-  .support.function.viewhelpers,
-  .support.function.activerecord,
-  .support.function.activesupport,
-  .keyword.special-method { .orange; }
+  .syntax--support.syntax--function.syntax--actionpack,
+  .syntax--support.syntax--function.syntax--viewhelpers,
+  .syntax--support.syntax--function.syntax--activerecord,
+  .syntax--support.syntax--function.syntax--activesupport,
+  .syntax--keyword.syntax--special-method { .syntax--orange; }
 
-  .meta.embedded,
-  .source.embedded {
+  .syntax--meta.syntax--embedded,
+  .syntax--source.syntax--embedded {
     .settings-embedded-mix;
 
-    .support.function.actionpack,
-    .support.function.viewhelpers,
-    .support.function.activerecord,
-    .support.function.activesupport,
-    .keyword.special-method { .reset; }
+    .syntax--support.syntax--function.syntax--actionpack,
+    .syntax--support.syntax--function.syntax--viewhelpers,
+    .syntax--support.syntax--function.syntax--activerecord,
+    .syntax--support.syntax--function.syntax--activesupport,
+    .syntax--keyword.syntax--special-method { .syntax--reset; }
 
-    .string.quoted {
-      .punctuation.definition { .reset; }
+    .syntax--string.syntax--quoted {
+      .syntax--punctuation.syntax--definition { .syntax--reset; }
     }
   }
 

--- a/styles/languages/rust.less
+++ b/styles/languages/rust.less
@@ -1,11 +1,11 @@
-.source.rust {
+.syntax--source.syntax--rust {
 
-  .keyword.other { .purple; }
+  .syntax--keyword.syntax--other { .syntax--purple; }
 
-  .storage.type { .orange; }
+  .syntax--storage.syntax--type { .syntax--orange; }
 
-  .comment {
-    .storage { .reset; }
+  .syntax--comment {
+    .syntax--storage { .syntax--reset; }
   }
 
 }

--- a/styles/languages/sass.less
+++ b/styles/languages/sass.less
@@ -1,18 +1,18 @@
-.source.sass {
+.syntax--source.syntax--sass {
 
-  .meta.selector {
-    .class {
-      .purple;
-      .punctuation.definition { .purple-sec; }
+  .syntax--meta.syntax--selector {
+    .syntax--class {
+      .syntax--purple;
+      .syntax--punctuation.syntax--definition { .syntax--purple-sec; }
     }
   }
 
-  .entity.tag { .purple; }
+  .syntax--entity.syntax--tag { .syntax--purple; }
 
-  .meta {
-    .variable.other { .blue; }
+  .syntax--meta {
+    .syntax--variable.syntax--other { .syntax--blue; }
   }
 
-  .support.constant { .green; }
+  .syntax--support.syntax--constant { .syntax--green; }
 
 }

--- a/styles/languages/scss.less
+++ b/styles/languages/scss.less
@@ -1,10 +1,10 @@
-.source.scss {
+.syntax--source.syntax--scss {
 
-  .meta {
-    .variable { .blue; }
+  .syntax--meta {
+    .syntax--variable { .syntax--blue; }
   }
 
-  .punctuation.separator.key-value,
-  .punctuation.terminator { .sec; }
+  .syntax--punctuation.syntax--separator.syntax--key-value,
+  .syntax--punctuation.syntax--terminator { .syntax--sec; }
 
 }

--- a/styles/languages/shell.less
+++ b/styles/languages/shell.less
@@ -1,10 +1,10 @@
-.source.shell {
+.syntax--source.syntax--shell {
 
-  .support.function.builtin { .orange; }
+  .syntax--support.syntax--function.syntax--builtin { .syntax--orange; }
 
-  .string.quoted {
-    .variable {
-      .punctuation { .reset; }
+  .syntax--string.syntax--quoted {
+    .syntax--variable {
+      .syntax--punctuation { .syntax--reset; }
     }
   }
 

--- a/styles/languages/slim.less
+++ b/styles/languages/slim.less
@@ -1,8 +1,8 @@
-.slim {
+.syntax--slim {
 
-  .entity.name.tag,
-  .punctuation.definition.tag { .purple; }
+  .syntax--entity.syntax--name.syntax--tag,
+  .syntax--punctuation.syntax--definition.syntax--tag { .syntax--purple; }
 
-  .entity.attribute-name { .blue; }
+  .syntax--entity.syntax--attribute-name { .syntax--blue; }
 
 }

--- a/styles/languages/stylus.less
+++ b/styles/languages/stylus.less
@@ -1,5 +1,5 @@
-// .stylus {
-//   .function .name {
-//     .duo-2();
+// .syntax--stylus {
+//   .syntax--function .syntax--name {
+//     .syntax--duo-2();
 //   }
 // }

--- a/styles/languages/text.less
+++ b/styles/languages/text.less
@@ -1,5 +1,5 @@
 // Text
 
-// .plain .text {
-//   .uno-1();
+// .syntax--plain .syntax--text {
+//   .syntax--uno-1();
 // }

--- a/styles/languages/yaml.less
+++ b/styles/languages/yaml.less
@@ -1,10 +1,10 @@
-.yaml {
+.syntax--yaml {
 
-  .constant.numeric { .reset; }
+  .syntax--constant.syntax--numeric { .syntax--reset; }
 
-  .entity.tag {
-    .purple;
-    .punctuation { .purple-sec; }
+  .syntax--entity.syntax--tag {
+    .syntax--purple;
+    .syntax--punctuation { .syntax--purple-sec; }
   }
 
 }


### PR DESCRIPTION
Prepended syntax selectors with 'syntax--' to remove deprecation warnings in Atom 1.13 and above.